### PR TITLE
lh-brackets: Catch no such mapping error during UnMap.

### DIFF
--- a/autoload/lh/brackets.vim
+++ b/autoload/lh/brackets.vim
@@ -262,9 +262,13 @@ endfunction
 
 " s:UnMap(m) {{{2
 function! s:UnMap(m) abort
-  let cmd = a:m.mode[0].'unmap '. a:m.buffer . a:m.trigger
-  if &verbose >= 1 | echomsg cmd | endif
-  exe cmd
+  try
+    let cmd = a:m.mode[0].'unmap '. a:m.buffer . a:m.trigger
+    if &verbose >= 1 | echomsg cmd | endif
+    exe cmd
+  catch /.*No such mapping.*/
+    if &verbose >= 1 | echomsg "no mapping for: ".cmd | endif
+  endtry
 endfunction
 
 " s:Map(m) {{{2


### PR DESCRIPTION
- In some cases, the UnMap command can fail, do not allow this
  to be a fatal error.

I actually put it in a dedicated branch this time :)

To be honest I don't know why this is happening.  But during toggling mappings (with \<F9>), I got an error that stopped script execution.  Turns out it was failing to unmap `<localleader><` saying it didn't exist...which it clearly did.  Once I put a try/catch in place and put in some debug I found it only had the error the first time through....

For your interested here are some screenshots showing my debug and errors:

First debug going through the mapping sequence (lh/brackets.vim#s:Map()):
![mappingdebug 2015-12-29 16 14 54](https://cloud.githubusercontent.com/assets/16273537/12043333/f19941b8-ae49-11e5-9e53-bf64dca37e0d.png)

Then a screenshot showing the Verbose version of the mapping, as I was hypothesizing perhaps a different plugin had mapped it, but slightly differently. But as you can see, the mapping present was done by lh/brackets.vim:
![verbose mapping screenshot 2015-12-29 16 16 18](https://cloud.githubusercontent.com/assets/16273537/12043346/1d03198c-ae4a-11e5-897c-66d873e19c6b.png)

Finally the error itself, with some surrounding debug in s:UnMap():
![unmapping error 2015-12-29 16 17 43](https://cloud.githubusercontent.com/assets/16273537/12043358/3bf353a2-ae4a-11e5-81a4-ff847c3467c5.png)
