### PR TITLE
lh-brackets: Use new lh-vim-lib compatibility functions.

### DIFF
--- a/autoload/lh/brackets.vim
+++ b/autoload/lh/brackets.vim
@@ -458,7 +458,7 @@ function! s:JumpOverAllClose(chars, ...) abort
   let ll = getline('.')[p : ] " ignore char under cursor, look after
   let m = matchstr(ll, '\v^(['.a:chars.']|'.lh#marker#txt('.{-}').')+')
   " echomsg ll.'##'.m.'##'
-  let lm = strwidth(m)
+  let lm = lh#string#strwidth(m)
   let len_match = lh#encoding#strlen(m)
   if lm
     let del_mark = repeat("\<del>", lm)
@@ -469,7 +469,7 @@ function! s:JumpOverAllClose(chars, ...) abort
     let remaining = ll[len_match : ]
     " echomsg "rem: <<".remaining.">>"
     let match_rem = matchstr(remaining, '^\('.lh#marker#txt('.\{-}').'\)*'.a:1.'\('.lh#marker#txt('.\{-}').'\)*')
-    let len_match_rem = strwidth(match_rem)
+    let len_match_rem = lh#string#strwidth(match_rem)
     if len_match_rem
       let del_mark = repeat("\<del>", len_match_rem).del_mark
     endif
@@ -502,7 +502,7 @@ function! s:Jump() abort
   let ll = getline('.')[p : ]
   " echomsg ll
   let m = matchstr(ll, '^'.lh#marker#txt('.\{-}'))
-  let lm = strwidth(m)
+  let lm = lh#string#strwidth(m)
   let del_mark = repeat("\<del>", lm)
   return s:k_move_prefix."\<right>".del_mark
 endfunction

--- a/autoload/lh/map.vim
+++ b/autoload/lh/map.vim
@@ -513,7 +513,7 @@ endfunction
 " See vim patch 7.4.849
 function! lh#map#_move_cursor_on_the_current_line(offset) abort
   let move = a:offset > 0 ? "\<right>" : "\<left>"
-  return repeat(s:k_move_prefix.move, abs(a:offset))
+  return repeat(s:k_move_prefix.move, lh#math#abs(a:offset))
 endfunction
 
 "------------------------------------------------------------------------

--- a/plugin/common_brackets.vim
+++ b/plugin/common_brackets.vim
@@ -215,6 +215,11 @@ endif
 
 "# Default brackets definitions {{{2
 if ! lh#option#get('cb_no_default_brackets', 0)
+  " For some reason older vim versions do not properly autoload the
+  " lh#ft#is_text wrapped in function() later in this definition.  Calling
+  " this verbose autoload function first will make sure the lh/ft.vim module
+  " is properly sourced.
+  let s:unneededverboseval = lh#ft#verbose()
   :Brackets! ( )
   :Brackets! [ ] -visual=0
   :Brackets! [ ] -insert=0 -trigger=<leader>[


### PR DESCRIPTION
I think the builds are failing because it requires the lh-vim-lib pull request to be merged in as a dependency :)